### PR TITLE
Fix an issue while closing a connector that does not implement `io.Closer`

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@ package otelsql
 // Version is the current release version of the otelsql instrumentation.
 func Version() string {
 	// This string is updated by the pre_release.sh script during release
-	return "0.1.0"
+	return "0.1.1"
 }
 
 // SemVersion is the semantic version to be supplied to tracer/meter creation.


### PR DESCRIPTION
Fix an issue while closing a connector that does not implement `io.Closer`