### PR TITLE
Correct metric name `db_sql_connections_idle_closed_count`

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,15 +437,15 @@ func openDB(dsn string) (*sql.DB, error) {
 
 ### Database Connection Metrics
 
-| Metric                                                              | Description                                                |
-|:--------------------------------------------------------------------|:-----------------------------------------------------------|
-| `db_sql_connections_active{db_instance,db_system,db_name}`          | Number of active connections                               |
-| `db_sql_connections_idle{db_instance,db_system,db_name}`            | Number of idle connections                                 |
-| `db_sql_connections_idle_closed{db_instance,db_system,db_name}`     | Total number of closed connections by `SetMaxIdleConns`    |
-| `db_sql_connections_lifetime_closed{db_instance,db_system,db_name}` | Total number of closed connections by `SetConnMaxLifetime` |
-| `db_sql_connections_open{db_instance,db_system,db_name}`            | Number of open connections                                 |
-| `db_sql_connections_wait_count{db_instance,db_system,db_name}`      | Total number of connections waited for                     |
-| `db_sql_connections_wait_duration{db_instance,db_system,db_name}`   | Total time blocked waiting for new connections             |
+| Metric                                                                | Description                                                |
+|:----------------------------------------------------------------------|:-----------------------------------------------------------|
+| `db_sql_connections_active{db_instance,db_system,db_name}`            | Number of active connections                               |
+| `db_sql_connections_idle{db_instance,db_system,db_name}`              | Number of idle connections                                 |
+| `db_sql_connections_idle_closed_count{db_instance,db_system,db_name}` | Total number of closed connections by `SetMaxIdleConns`    |
+| `db_sql_connections_lifetime_closed{db_instance,db_system,db_name}`   | Total number of closed connections by `SetConnMaxLifetime` |
+| `db_sql_connections_open{db_instance,db_system,db_name}`              | Number of open connections                                 |
+| `db_sql_connections_wait_count{db_instance,db_system,db_name}`        | Total number of connections waited for                     |
+| `db_sql_connections_wait_duration{db_instance,db_system,db_name}`     | Total time blocked waiting for new connections             |
 
 [<sub><sup>[table of contents]</sup></sub>](#table-of-contents)
 
@@ -538,15 +538,15 @@ The `interval` in `RecordStats()` is replaced with `WithMinimumReadDBStatsInterv
 
 **Connection Metrics**
 
-| `ocsql`                                                        | `otelsql`                                                           |
-|:---------------------------------------------------------------|:--------------------------------------------------------------------|
-| `go_sql_db_connections_active{go_sql_instance}`                | `db_sql_connections_active{db_instance,db_system,db_name}`          |
-| `go_sql_db_connections_idle{go_sql_instance}`                  | `db_sql_connections_idle{db_instance,db_system,db_name}`            |
-| `go_sql_db_connections_idle_closed_count{go_sql_instance}`     | `db_sql_connections_idle_closed{db_instance,db_system,db_name}`     |
-| `go_sql_db_connections_lifetime_closed_count{go_sql_instance}` | `db_sql_connections_lifetime_closed{db_instance,db_system,db_name}` |
-| `go_sql_db_connections_open{go_sql_instance}`                  | `db_sql_connections_open{db_instance,db_system,db_name}`            |
-| `go_sql_db_connections_wait_count{go_sql_instance}`            | `db_sql_connections_wait_count{db_instance,db_system,db_name}`      |
-| `go_sql_db_connections_wait_duration{go_sql_instance}`         | `db_sql_connections_wait_duration{db_instance,db_system,db_name}`   |
+| `ocsql`                                                        | `otelsql`                                                             |
+|:---------------------------------------------------------------|:----------------------------------------------------------------------|
+| `go_sql_db_connections_active{go_sql_instance}`                | `db_sql_connections_active{db_instance,db_system,db_name}`            |
+| `go_sql_db_connections_idle{go_sql_instance}`                  | `db_sql_connections_idle{db_instance,db_system,db_name}`              |
+| `go_sql_db_connections_idle_closed_count{go_sql_instance}`     | `db_sql_connections_idle_closed_count{db_instance,db_system,db_name}` |
+| `go_sql_db_connections_lifetime_closed_count{go_sql_instance}` | `db_sql_connections_lifetime_closed{db_instance,db_system,db_name}`   |
+| `go_sql_db_connections_open{go_sql_instance}`                  | `db_sql_connections_open{db_instance,db_system,db_name}`              |
+| `go_sql_db_connections_wait_count{go_sql_instance}`            | `db_sql_connections_wait_count{db_instance,db_system,db_name}`        |
+| `go_sql_db_connections_wait_duration{go_sql_instance}`         | `db_sql_connections_wait_duration{db_instance,db_system,db_name}`     |
 
 [<sub><sup>[table of contents]</sup></sub>](#table-of-contents)
 

--- a/metric.go
+++ b/metric.go
@@ -9,6 +9,6 @@ const (
 	dbSQLConnectionsActive         = "db.sql.connections.active"
 	dbSQLConnectionsWaitCount      = "db.sql.connections.wait_count"
 	dbSQLConnectionsWaitDuration   = "db.sql.connections.wait_duration"
-	dbSQLConnectionsIdleClosed     = "db.sql.connections.idle_closed"
+	dbSQLConnectionsIdleClosed     = "db.sql.connections.idle_closed_count"
 	dbSQLConnectionsLifetimeClosed = "db.sql.connections.lifetime_closed"
 )

--- a/resources/fixtures/metrics/stats.json
+++ b/resources/fixtures/metrics/stats.json
@@ -4,7 +4,7 @@
         "Last": 0
     },
     {
-        "Name": "db.sql.connections.idle_closed{service.name=otelsql,instrumentation.name=github.com/nhatthm/otelsql,db.instance=default,db.system=postgresql}",
+        "Name": "db.sql.connections.idle_closed_count{service.name=otelsql,instrumentation.name=github.com/nhatthm/otelsql,db.instance=default,db.system=postgresql}",
         "Last": 0
     },
     {

--- a/stats_test.go
+++ b/stats_test.go
@@ -55,7 +55,7 @@ func TestRecordStats_Error(t *testing.T) {
 		{metric: "db.sql.connections.active"},
 		{metric: "db.sql.connections.wait_count"},
 		{metric: "db.sql.connections.wait_duration"},
-		{metric: "db.sql.connections.idle_closed"},
+		{metric: "db.sql.connections.idle_closed_count"},
 		{metric: "db.sql.connections.lifetime_closed"},
 	}
 


### PR DESCRIPTION
## Description

Correct metric name `db_sql_connections_idle_closed_count`