### PR TITLE
Add `x/trace` to provide some extra functionalities

### DIFF
--- a/x/trace/doc.go
+++ b/x/trace/doc.go
@@ -1,0 +1,2 @@
+// Package trace provides extra functionalities for tracing with otelsql.
+package trace

--- a/x/trace/options.go
+++ b/x/trace/options.go
@@ -1,0 +1,22 @@
+package trace
+
+import (
+	"context"
+	"database/sql/driver"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+
+	"github.com/nhatthm/otelsql"
+)
+
+// TransformAndTraceQueryWithoutArgs transforms the query using a given function and adds that to the span without arguments.
+//
+//    trace.TransformAndTraceQueryWithoutArgs(strings.TrimSpace)
+func TransformAndTraceQueryWithoutArgs(transform func(query string) string) otelsql.DriverOption {
+	return otelsql.TraceQuery(func(ctx context.Context, query string, args []driver.NamedValue) []attribute.KeyValue {
+		return []attribute.KeyValue{
+			semconv.DBStatementKey.String(transform(query)),
+		}
+	})
+}

--- a/x/trace/options_test.go
+++ b/x/trace/options_test.go
@@ -1,0 +1,96 @@
+package trace_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/nhatthm/otelsql"
+	"github.com/nhatthm/otelsql/internal/test/oteltest"
+	xtrace "github.com/nhatthm/otelsql/x/trace"
+)
+
+func Test_TransformAndTraceQueryWithoutArgs(t *testing.T) {
+	t.Parallel()
+
+	expectedTraceWithQuery := expectedExecTraceWithQuery(sampleParentSpanIDs())
+
+	oteltest.New(
+		oteltest.TracesEqualJSON(expectedTraceWithQuery),
+		oteltest.MockDatabase(func(m sqlmock.Sqlmock) {
+			m.ExpectExec(`    DELETE FROM data WHERE country = $1    `).
+				WithArgs("US").
+				WillReturnResult(sqlmock.NewResult(0, 10))
+		}),
+	).
+		Run(t, func(sc oteltest.SuiteContext) {
+			db, err := newDB(sc.DatabaseDSN(),
+				otelsql.WithMeterProvider(sc.MeterProvider()),
+				otelsql.WithTracerProvider(sc.TracerProvider()),
+				xtrace.TransformAndTraceQueryWithoutArgs(strings.TrimSpace),
+			)
+			require.NoError(t, err)
+
+			defer db.Close() // nolint: errcheck
+
+			result, err := db.ExecContext(contextWithSampleSpan(), `    DELETE FROM data WHERE country = $1    `, "US")
+
+			require.NoError(t, err)
+
+			affectedRows, err := result.RowsAffected()
+
+			require.Equal(t, int64(10), affectedRows)
+			require.NoError(t, err)
+		})
+}
+
+func newDB(dsn string, opts ...otelsql.DriverOption) (*sql.DB, error) {
+	driverName, err := otelsql.RegisterWithSource("sqlmock", dsn, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func contextWithSampleSpan() context.Context {
+	return oteltest.BackgroundWithSpanContext(sampleParentSpanIDs())
+}
+
+func sampleParentSpanIDs() (trace.TraceID, trace.SpanID) {
+	return oteltest.SampleTraceID, oteltest.SampleSpanID
+}
+
+func mustNotFail(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getFixture(file string, args ...interface{}) string {
+	data, err := os.ReadFile(filepath.Clean(file))
+	mustNotFail(err)
+
+	return fmt.Sprintf(string(data), args...)
+}
+
+func expectedTracesFromFile(file string, args ...interface{}) string {
+	return getFixture("../../resources/fixtures/traces/"+file, args...)
+}
+
+func expectedExecTraceWithQuery(parentTraceID trace.TraceID, parentSpanID trace.SpanID) string {
+	return expectedTracesFromFile("exec_with_query.json", parentTraceID, parentSpanID)
+}


### PR DESCRIPTION
## Description

Add `x/trace` to provide some extra functionalities:
- `TransformAndTraceQueryWithoutArgs` transforms the query using a given function and adds that to the span without arguments.