### PR TITLE
Proper function name for milliseconds since.

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -36,7 +36,7 @@ func (r methodRecorderImpl) Record(ctx context.Context, method string, labels ..
 	attrs = append(attrs, semconv.DBOperationKey.String(method))
 
 	return func(err error) {
-		elapsedTime := microsecondsSince(startTime)
+		elapsedTime := millisecondsSince(startTime)
 
 		if err == nil {
 			attrs = append(attrs, dbSQLStatusOK)

--- a/time.go
+++ b/time.go
@@ -2,6 +2,6 @@ package otelsql
 
 import "time"
 
-func microsecondsSince(t time.Time) float64 {
-	return float64(time.Since(t).Nanoseconds()) / 1e6
+func millisecondsSince(t time.Time) float64 {
+	return float64(time.Since(t).Milliseconds())
 }


### PR DESCRIPTION
The function `microsecondsSince` returns milliseconds. Then the
function's name has been changed to `millisecondsSince`.