### PR TITLE
make sure otel.Handle is called only if err != nil

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -139,13 +139,13 @@ func newConnConfig(opts driverOptions) connConfig {
 		metric.WithUnit(unitMilliseconds),
 		metric.WithDescription(`The distribution of latencies of various calls in milliseconds`),
 	)
-	mustHandleErr(err)
+	mustNoError(err)
 
 	callsCounter, err := meter.Int64Counter(dbSQLClientCalls,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription(`The number of various calls of methods`),
 	)
-	mustHandleErr(err)
+	mustNoError(err)
 
 	latencyRecorder := newMethodRecorder(latencyMsHistogram.Record, callsCounter.Add, opts.defaultAttributes...)
 

--- a/driver.go
+++ b/driver.go
@@ -139,13 +139,13 @@ func newConnConfig(opts driverOptions) connConfig {
 		metric.WithUnit(unitMilliseconds),
 		metric.WithDescription(`The distribution of latencies of various calls in milliseconds`),
 	)
-	handleErr(err)
+	mustHandleErr(err)
 
 	callsCounter, err := meter.Int64Counter(dbSQLClientCalls,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription(`The number of various calls of methods`),
 	)
-	handleErr(err)
+	mustHandleErr(err)
 
 	latencyRecorder := newMethodRecorder(latencyMsHistogram.Record, callsCounter.Add, opts.defaultAttributes...)
 
@@ -213,10 +213,4 @@ func (d otDriver) Connect(ctx context.Context) (driver.Conn, error) {
 
 func (d otDriver) Driver() driver.Driver {
 	return d
-}
-
-func handleErr(err error) {
-	if err != nil {
-		panic(err)
-	}
 }

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,7 @@ func handleErr(err error) {
 	}
 }
 
-func mustHandleErr(err error) {
+func mustNoError(err error) {
 	if err != nil {
 		panic(err)
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,15 @@
+package otelsql
+
+import "go.opentelemetry.io/otel"
+
+func handleErr(err error) {
+	if err != nil {
+		otel.Handle(err)
+	}
+}
+
+func mustHandleErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/errors_internal_test.go
+++ b/errors_internal_test.go
@@ -11,11 +11,11 @@ func TestHandleError(t *testing.T) {
 	t.Parallel()
 
 	assert.Panics(t, func() {
-		mustHandleErr(errors.New("error"))
+		mustNoError(errors.New("error"))
 	})
 
 	assert.NotPanics(t, func() {
-		mustHandleErr(nil)
+		mustNoError(nil)
 	})
 
 	assert.NotPanics(t, func() {

--- a/errors_internal_test.go
+++ b/errors_internal_test.go
@@ -11,10 +11,18 @@ func TestHandleError(t *testing.T) {
 	t.Parallel()
 
 	assert.Panics(t, func() {
-		handleErr(errors.New("error"))
+		mustHandleErr(errors.New("error"))
+	})
+
+	assert.NotPanics(t, func() {
+		mustHandleErr(nil)
 	})
 
 	assert.NotPanics(t, func() {
 		handleErr(nil)
+	})
+
+	assert.NotPanics(t, func() {
+		handleErr(assert.AnError)
 	})
 }

--- a/stats.go
+++ b/stats.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
@@ -74,49 +73,49 @@ func recordStats(
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription("Count of open connections in the pool"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	idleConnections, err = meter.Int64ObservableGauge(
 		dbSQLConnectionsIdle,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription("Count of idle connections in the pool"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	activeConnections, err = meter.Int64ObservableGauge(
 		dbSQLConnectionsActive,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription("Count of active connections in the pool"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	waitCount, err = meter.Int64ObservableGauge(
 		dbSQLConnectionsWaitCount,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription("The total number of connections waited for"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	waitDuration, err = meter.Float64ObservableGauge(
 		dbSQLConnectionsWaitDuration,
 		metric.WithUnit(unitMilliseconds),
 		metric.WithDescription("The total time blocked waiting for a new connection"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	idleClosed, err = meter.Int64ObservableGauge(
 		dbSQLConnectionsIdleClosed,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription("The total number of connections closed due to SetMaxIdleConns"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	lifetimeClosed, err = meter.Int64ObservableGauge(
 		dbSQLConnectionsLifetimeClosed,
 		metric.WithUnit(unitDimensionless),
 		metric.WithDescription("The total number of connections closed due to SetConnMaxLifetime"),
 	)
-	otel.Handle(err)
+	handleErr(err)
 
 	_, err = meter.RegisterCallback(func(ctx context.Context, obs metric.Observer) error {
 		lock.Lock()


### PR DESCRIPTION
If I run my application with otelsql for a sql storage. I have the following in my logs:

2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>
2023/05/19 11:58:25 <nil>

Otelsql uses otel.Handle function regardless of error value.
I suppose nil errors shouldn't go to logs at all.

I'm suggesting this PR in order to handle nil errors silently.