### PR TITLE
Wrap conn created with connector

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -208,7 +208,7 @@ func (d otDriver) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, err
 	}
 
-	return makeConn(c, d.connConfig), nil
+	return wrapConn(c, d.connConfig), nil
 }
 
 func (d otDriver) Driver() driver.Driver {

--- a/driver_test.go
+++ b/driver_test.go
@@ -186,15 +186,14 @@ func TestWrap_DriverContext_ConnectNamedValueChecker(t *testing.T) {
 	}
 
 	drv := otelsql.Wrap(parent).(driver.DriverContext) // nolint: errcheck
-	connector, err := drv.OpenConnector("")
 
-	assert.NoError(t, err)
+	connector, err := drv.OpenConnector("")
+	require.NoError(t, err)
 
 	conn, err := connector.Connect(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Implements(t, (*driver.NamedValueChecker)(nil), conn)
-
 }
 
 func TestWrap_DriverContext_CloseBeforeOpenConnector(t *testing.T) {


### PR DESCRIPTION
If the parent driver implements NamedValueChecker or SessionResetter interface, the conn created using connector needs to be wrapped to avoid obscuring the implementations.