### PR TITLE
Bug/missing AllowRoot panics no context methods

### DIFF
--- a/query.go
+++ b/query.go
@@ -79,7 +79,7 @@ func makeQueryerContextMiddlewares(r methodRecorder, t methodTracer, cfg queryCo
 
 	middlewares = append(middlewares, queryStats(r, cfg.metricMethod))
 
-	if t != nil {
+	if t == nil {
 		return middlewares
 	}
 

--- a/query.go
+++ b/query.go
@@ -77,10 +77,13 @@ func queryWrapRows(t methodTracer, traceLastInsertID bool, traceRowsAffected boo
 func makeQueryerContextMiddlewares(r methodRecorder, t methodTracer, cfg queryConfig) []queryContextFuncMiddleware {
 	middlewares := make([]queryContextFuncMiddleware, 0, 3)
 
-	middlewares = append(middlewares,
-		queryStats(r, cfg.metricMethod),
-		queryTrace(t, cfg.traceQuery, cfg.traceMethod),
-	)
+	middlewares = append(middlewares, queryStats(r, cfg.metricMethod))
+
+	if t != nil {
+		return middlewares
+	}
+
+	middlewares = append(middlewares, queryTrace(t, cfg.traceQuery, cfg.traceMethod))
 
 	if cfg.traceRowsNext || cfg.traceRowsClose {
 		middlewares = append(middlewares, queryWrapRows(t, cfg.traceRowsNext, cfg.traceRowsClose))


### PR DESCRIPTION
If you setup otelsql without passing `otelsql.AllowRoot()` any calls to a "No Context" variant of the query methods will cause a panic in the runtime.

This PR solves this by making sure that `methodTracer` isn't null before applying the `queryTrace` function to the middlewares. 