### PR TITLE
avoid allocating attributes when the span is not recording

### DIFF
--- a/attribute/attribute_test.go
+++ b/attribute/attribute_test.go
@@ -54,6 +54,9 @@ func BenchmarkFromNamedValue(b *testing.B) {
 		}
 	}
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		for _, v := range namedValues {
 			xattr.FromNamedValue(v)
@@ -64,6 +67,9 @@ func BenchmarkFromNamedValue(b *testing.B) {
 func BenchmarkKeyValueDuration(b *testing.B) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano())) // nolint: gosec
 	d := time.Duration(r.Int63n(int64(10 * time.Second)))
+
+	b.ReportAllocs()
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		xattr.KeyValueDuration(key, d)

--- a/begin_internal_test.go
+++ b/begin_internal_test.go
@@ -32,6 +32,9 @@ func BenchmarkBeginStats(b *testing.B) {
 		beginStats(r),
 	}, nopBegin)
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		_, _ = begin(context.Background(), driver.TxOptions{}) // nolint: errcheck
 	}

--- a/exec_internal_test.go
+++ b/exec_internal_test.go
@@ -32,6 +32,9 @@ func BenchmarkExecStats(b *testing.B) {
 		execStats(r, metricMethodExec),
 	}, nopExecContext)
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		_, _ = exec(context.Background(), "", nil) // nolint: errcheck
 	}

--- a/ping_internal_test.go
+++ b/ping_internal_test.go
@@ -31,6 +31,9 @@ func BenchmarkPingStats(b *testing.B) {
 		pingStats(r),
 	}, nopPing)
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		_ = ping(context.Background()) // nolint: errcheck
 	}

--- a/prepare_internal_test.go
+++ b/prepare_internal_test.go
@@ -32,6 +32,9 @@ func BenchmarkPrepareStats(b *testing.B) {
 		prepareStats(r),
 	}, nopPrepareContext)
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		_, _ = prepare(context.Background(), "") // nolint: errcheck
 	}

--- a/query_internal_test.go
+++ b/query_internal_test.go
@@ -32,6 +32,9 @@ func BenchmarkQueryStats(b *testing.B) {
 		queryStats(r, metricMethodQuery),
 	}, nopQueryContext)
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		_, _ = query(context.Background(), "", nil) // nolint: errcheck
 	}

--- a/recorder.go
+++ b/recorder.go
@@ -47,8 +47,9 @@ func (r methodRecorderImpl) Record(ctx context.Context, method string, labels ..
 			)
 		}
 
-		r.countCalls(ctx, 1, metric.WithAttributes(attrs...))
-		r.recordLatency(ctx, elapsedTime, metric.WithAttributes(attrs...))
+		set := attribute.NewSet(attrs...)
+		r.countCalls(ctx, 1, metric.WithAttributeSet(set))
+		r.recordLatency(ctx, elapsedTime, metric.WithAttributeSet(set))
 	}
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -63,6 +63,11 @@ func (t *methodTracerImpl) MustTrace(ctx context.Context, method string, labels 
 	ctx, span := t.tracer.Start(ctx, t.formatSpanName(ctx, method), //nolint: spancheck
 		trace.WithSpanKind(trace.SpanKindClient),
 	)
+	if !span.IsRecording() {
+		return ctx, func(err error, attrs ...attribute.KeyValue) {
+			span.End()
+		}
+	}
 
 	attrs := make([]attribute.KeyValue, 0, len(t.attributes)+len(labels)+1)
 

--- a/tracer.go
+++ b/tracer.go
@@ -5,7 +5,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -62,7 +61,6 @@ func (t *methodTracerImpl) Trace(ctx context.Context, method string, labels ...a
 
 func (t *methodTracerImpl) MustTrace(ctx context.Context, method string, labels ...attribute.KeyValue) (context.Context, func(err error, attrs ...attribute.KeyValue)) {
 	ctx, span := t.tracer.Start(ctx, t.formatSpanName(ctx, method), //nolint: spancheck
-		trace.WithTimestamp(time.Now()),
 		trace.WithSpanKind(trace.SpanKindClient),
 	)
 
@@ -84,9 +82,7 @@ func (t *methodTracerImpl) MustTrace(ctx context.Context, method string, labels 
 			span.RecordError(err)
 		}
 
-		span.End(
-			trace.WithTimestamp(time.Now()),
-		)
+		span.End()
 	}
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -64,7 +64,7 @@ func (t *methodTracerImpl) MustTrace(ctx context.Context, method string, labels 
 		trace.WithSpanKind(trace.SpanKindClient),
 	)
 	if !span.IsRecording() {
-		return ctx, func(err error, attrs ...attribute.KeyValue) {
+		return ctx, func(_ error, _ ...attribute.KeyValue) {
 			span.End()
 		}
 	}


### PR DESCRIPTION
Good day,

While doing some more profiling I noticed that even when setting our sampling rate very slow a lot of allocations in otelsql still occurred. 
This PR avoid allocating attributes, setting errors etc when the span is not recording, It also removed the `time.Now` invocations as start and end times are already handled by OTEL by default and avoid creating 2 attribute sets when recording metrics. 

Please let me know what you think and have a great day!