### PR TITLE
Deprecated WithMinimumReadDBStatsInterval option

### DIFF
--- a/options.go
+++ b/options.go
@@ -227,19 +227,17 @@ func TraceLastInsertID() DriverOption {
 	})
 }
 
-// WithMinimumReadDBStatsInterval sets the minimum interval between calls to db.Stats(). Negative values are ignored.
-func WithMinimumReadDBStatsInterval(interval time.Duration) StatsOption {
-	return statsOptionFunc(func(o *statsOptions) {
-		o.minimumReadDBStatsInterval = interval
-	})
+// WithMinimumReadDBStatsInterval does nothing.
+//
+// Deprecated: does not have any effect since [database/sql.DB.Stats] calls are
+// cheap.
+func WithMinimumReadDBStatsInterval(_ time.Duration) StatsOption {
+	return statsOptionFunc(func(_ *statsOptions) {})
 }
 
 type statsOptions struct {
 	// meterProvider sets the metric.MeterProvider. If nil, the global Provider will be used.
 	meterProvider metric.MeterProvider
-
-	// minimumReadDBStatsInterval sets the minimum interval between calls to db.Stats(). Negative values are ignored.
-	minimumReadDBStatsInterval time.Duration
 
 	// defaultAttributes will be set to each metrics as default.
 	defaultAttributes []attribute.KeyValue

--- a/stats_test.go
+++ b/stats_test.go
@@ -2,7 +2,6 @@ package otelsql_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
@@ -29,7 +28,6 @@ func TestRecordStats(t *testing.T) {
 
 			err = otelsql.RecordStats(db,
 				otelsql.WithMeterProvider(sc.MeterProvider()),
-				otelsql.WithMinimumReadDBStatsInterval(100*time.Millisecond),
 				otelsql.WithInstanceName("default"),
 				otelsql.WithSystem(semconv.DBSystemPostgreSQL),
 			)


### PR DESCRIPTION
This option is not necessary since `database/sql.DB.Stats` calls are cheap. Note that [go.opentelemetry.io/contrib/instrumentation/runtime](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/runtime) instrumentation has a similar option `WithMinimumReadMemStatsInterval`, but for `runtime.ReadMemStats` that actually has a noticable performance impact (it does `stopTheWorld` to read stats).

`database/sql.DB.Stats`, on the other hand, simply acquires a mutex for a short duration to return a consistent snapshot of database statistics.