### PR TITLE
Bump database server versions

### DIFF
--- a/.github/workflows/test-compatibility-libpq.yaml
+++ b/.github/workflows/test-compatibility-libpq.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         go-version: ${{ fromJson(needs.setup.outputs.go-supported-versions) }}
         arch: [ "386", amd64 ]
-        postgres-version: [ "13", "14", "15", "16", "17" ]
+        postgres-version: [ "14", "15", "16", "17", "18" ]
     runs-on: ubuntu-latest
     needs: [setup]
     steps:

--- a/.github/workflows/test-compatibility-mssql.yaml
+++ b/.github/workflows/test-compatibility-mssql.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         go-version: ${{ fromJson(needs.setup.outputs.go-supported-versions) }}
         arch: [ "386", amd64 ]
-        mssql-version: [ "2019" ]
+        mssql-version: [ "2019", "2022", "2025" ]
     runs-on: ubuntu-latest
     needs: [setup]
     steps:

--- a/.github/workflows/test-compatibility-mysql.yaml
+++ b/.github/workflows/test-compatibility-mysql.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         go-version: ${{ fromJson(needs.setup.outputs.go-supported-versions) }}
         arch: [ "386", amd64 ]
-        mysql-version: [ "8" ]
+        mysql-version: [ "8", "9" ]
     runs-on: ubuntu-latest
     needs: [setup]
     steps:

--- a/.github/workflows/test-compatibility-pgx.yaml
+++ b/.github/workflows/test-compatibility-pgx.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         go-version: ${{ fromJson(needs.setup.outputs.go-supported-versions) }}
         arch: [ "386", amd64 ]
-        postgres-version: [ "13", "14", "15", "16", "17" ]
+        postgres-version: [ "14", "15", "16", "17", "18" ]
         pgx-version: [ "v4", "v5"]
     runs-on: ubuntu-latest
     needs: [setup]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add a OpenTelemetry wrapper to your existing database code to instrument the int
 
 ## Prerequisites
 
-- `Go >= 1.22`
+- `Go >= 1.24`
 
 [<sub><sup>[table of contents]</sup></sub>](#table-of-contents)
 
@@ -599,12 +599,12 @@ The traces are almost identical with some minor changes:
             <th colspan="2">Windows</th>
         </tr>
         <tr>
-            <th>go 1.22</th>
-            <th>go 1.23</th>
-            <th>go 1.22</th>
-            <th>go 1.23</th>
-            <th>go 1.22</th>
-            <th>go 1.23</th>
+            <th>go 1.24</th>
+            <th>go 1.25</th>
+            <th>go 1.24</th>
+            <th>go 1.25</th>
+            <th>go 1.24</th>
+            <th>go 1.25</th>
         </tr>
     </thead>
     <tbody>
@@ -633,7 +633,7 @@ The traces are almost identical with some minor changes:
                 <code style="white-space: nowrap">denisenkom/go-mssqldb</code>
             </td>
             <td style="white-space: nowrap">
-                SQL Server 2019
+                SQL Server 2019, 2022, 2025
             </td>
             <td colspan="6" align="center">
                 <a href="https://github.com/nhatthm/otelsql/actions/workflows/test-compatibility-mssql.yaml">
@@ -648,7 +648,7 @@ The traces are almost identical with some minor changes:
                 <code style="white-space: nowrap">go-sql-driver/mysql</code>
             </td>
             <td style="white-space: nowrap">
-                MySQL 8
+                MySQL 8, 9
             </td>
             <td colspan="6" align="center">
                 <a href="https://github.com/nhatthm/otelsql/actions/workflows/test-compatibility-mysql.yaml">
@@ -663,7 +663,7 @@ The traces are almost identical with some minor changes:
                 <code style="white-space: nowrap">jackc/pgx/v4/stdlib</code>
             </td>
             <td style="white-space: nowrap">
-                Postgres 13, 14, 15, 16, 17
+                Postgres 14, 15, 16, 17, 18
             </td>
             <td colspan="6" align="center">
                 <a href="https://github.com/nhatthm/otelsql/actions/workflows/test-compatibility-pgx.yaml">
@@ -678,7 +678,7 @@ The traces are almost identical with some minor changes:
                 <code style="white-space: nowrap">jackc/pgx/v5/stdlib</code>
             </td>
             <td style="white-space: nowrap">
-                Postgres 13, 14, 15, 16, 17
+                Postgres 14, 15, 16, 17, 18
             </td>
             <td colspan="6" align="center">
                 <a href="https://github.com/nhatthm/otelsql/actions/workflows/test-compatibility-pgx.yaml">
@@ -693,7 +693,7 @@ The traces are almost identical with some minor changes:
                 <code style="white-space: nowrap">lib/pq</code>
             </td>
             <td style="white-space: nowrap">
-                Postgres 13, 14, 15, 16, 17
+                Postgres 14, 15, 16, 17, 18
             </td>
             <td colspan="6" align="center">
                 <a href="https://github.com/nhatthm/otelsql/actions/workflows/test-compatibility-libpq.yaml">

--- a/tests/postgres/main_test.go
+++ b/tests/postgres/main_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultVersion = "12-alpine"
+	defaultVersion = "14-alpine"
 	defaultDriver  = "pgx/v4"
 
 	databaseName     = "otelsql"


### PR DESCRIPTION
## Description

Bump database server versions

* `mssql`: Added 2022, 2025
* `mysql`: Added 9
* `psql`: Removed 13, Added 18